### PR TITLE
Fix macOS version

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 #target = "wasm32-unknown-unknown"
+
+[target.x86_64-apple-darwin]
+rustflags=["-C", "link-arg=-mmacosx-version-min=10.12"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ build my own. It parses all your mails and shows configurable clusters of mails 
 - Additional filters for seen mails or tags / labels
 - See all the mails for the current set of filters / current cluster
 - Save the generated database as a SQLite file so you can do additional queries yourself (or open it again)
-- Cross platform (macOS, Windows, Linux and a [Web Demo](https://terhech.de/postsack_demo))
+- Cross platform (macOS (from 10.12 onward), Windows, Linux and a [Web Demo](https://terhech.de/postsack_demo))
 - The app is 13MB big and consumes ~150MB of memory on macOS
 
 The look is similar on all platforms as it uses the [Rust egui](https://github.com/emilk/egui) GUI library.

--- a/postsack-native/Cargo.toml
+++ b/postsack-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postsack"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Provides a high level visual overview of swaths of email"
 

--- a/postsack-native/Cargo.toml
+++ b/postsack-native/Cargo.toml
@@ -14,7 +14,7 @@ version = "1.0.0"
 copyright = "Copyright (c) Benedikt Terhechte (2021). All rights reserved."
 category = "Developer Tool"
 short_description = "Provides a high level visual overview of swaths of email"
-osx_minimum_system_version = "10.14"
+osx_minimum_system_version = "10.12"
 
 [dependencies]
 ps-gui = { path = "../ps-gui" }

--- a/postsack-native/build_mac.sh
+++ b/postsack-native/build_mac.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+# Compile for older macOS Versions
+# See: https://users.rust-lang.org/t/compile-rust-binary-for-older-versions-of-mac-osx/38695/2
+export MACOSX_DEPLOYMENT_TARGET=10.10
+
 rm -rf ../target/release/bundle/osx/Postsack.app
 
 # Build for x86 and ARM


### PR DESCRIPTION
This should allow Postsack to run on older macOS versions. I got it to run on High Sierra, however it crashes on start because I'm only running it in a VM (Virtualbox) and apparently `Glutin` [requires multi-sampling which most VM's don't support.](https://github.com/PistonDevelopers/conrod/issues/1031) It should work fine on real hardware though.